### PR TITLE
style(ui): 为选择器和按钮组件添加 nowrap 样式防止文本换行

### DIFF
--- a/crates/ui/src/components/ui/select/style.css
+++ b/crates/ui/src/components/ui/select/style.css
@@ -22,6 +22,7 @@
   font-weight: 900;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+  white-space: nowrap;
   transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 .select-trigger span[data-placeholder="true"] {
@@ -127,6 +128,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  white-space: nowrap;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 .select-option[data-disabled="true"] {

--- a/crates/ui/src/components/views/repo/list/repo_list_handler.rs
+++ b/crates/ui/src/components/views/repo/list/repo_list_handler.rs
@@ -45,7 +45,6 @@ pub(super) fn RepoListHandler() -> Element {
                     SelectTrigger {
                         class: "select-trigger w-full min-w-0 px-2 py-2 text-[10px] tracking-[0.08em] md:min-w-[9rem] md:px-4 md:py-3 md:text-xs md:tracking-[0.14em]",
                         aria_label: t!("view_repo_list_handler_filter_aria_label"),
-                        style: "min-width: 0;",
                         SelectValue {}
                     }
                     SelectList { aria_label: t!("view_repo_list_handler_filter_options_aria_label"),
@@ -95,7 +94,6 @@ pub(super) fn RepoListHandler() -> Element {
                     SelectTrigger {
                         class: "select-trigger w-full min-w-0 px-2 py-2 text-[10px] tracking-[0.08em] md:min-w-[7rem] md:px-4 md:py-3 md:text-xs md:tracking-[0.14em]",
                         aria_label: t!("view_repo_list_handler_page_size_aria_label"),
-                        style: "min-width: 0;",
                         SelectValue {}
                     }
                     SelectList { aria_label: t!("view_repo_list_handler_page_size_options_aria_label"),
@@ -152,7 +150,6 @@ pub(super) fn RepoListHandler() -> Element {
                     SelectTrigger {
                         class: "select-trigger w-full min-w-0 px-2 py-2 text-[10px] tracking-[0.08em] md:min-w-[10rem] md:px-4 md:py-3 md:text-xs md:tracking-[0.14em]",
                         aria_label: t!("view_repo_list_handler_sort_aria_label"),
-                        style: "min-width: 0;",
                         SelectValue {}
                     }
                     SelectList { aria_label: t!("view_repo_list_handler_sort_options_aria_label"),


### PR DESCRIPTION
Fixes  #5 

为tag页面中的日期筛选添加新的样式，确保选择中文不会换行，具体样式如下

英文
<img width="1139" height="730" alt="image" src="https://github.com/user-attachments/assets/6370636d-cc49-43af-a581-ca37d83c9c85" />

中文
<img width="1031" height="748" alt="image" src="https://github.com/user-attachments/assets/bd83f769-09a2-4cc8-99e8-6a83e367e675" />

Tips:是否考虑为项目添加一个pr模版