### PR TITLE
Refactor: 重构搜索功能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "dioxus-attributes"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/components#8d65778356dfd5415cf4b1b7261f185551840261"
+source = "git+https://github.com/DioxusLabs/components#ccdb07f69383de008a0afadda0e5ab7ec14c1a9c"
 dependencies = [
  "dioxus-rsx",
  "proc-macro2",
@@ -1499,13 +1499,14 @@ dependencies = [
 [[package]]
 name = "dioxus-primitives"
 version = "0.0.1"
-source = "git+https://github.com/DioxusLabs/components#8d65778356dfd5415cf4b1b7261f185551840261"
+source = "git+https://github.com/DioxusLabs/components#ccdb07f69383de008a0afadda0e5ab7ec14c1a9c"
 dependencies = [
  "dioxus",
  "dioxus-attributes",
  "dioxus-sdk-time",
  "lazy-js-bundle 0.6.2",
  "num-integer",
+ "serde",
  "time",
  "tracing",
 ]
@@ -3170,7 +3171,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3273,7 +3274,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.16",
  "http",
@@ -5899,7 +5900,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/adapters/src/persistence/psql/repo_repo.rs
+++ b/crates/adapters/src/persistence/psql/repo_repo.rs
@@ -285,7 +285,7 @@ impl RepoRepo for PostgresRepoRepo {
         Ok(rows.into_iter().map(Into::into).collect())
     }
 
-    async fn list(&self, page: Pagination) -> AppResult<Page<Repo>> {
+    async fn list_repos(&self, page: Pagination) -> AppResult<Page<Repo>> {
         let limit = page.limit();
         let offset = page.offset();
         let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM repos")
@@ -430,7 +430,7 @@ impl RepoRepo for PostgresRepoRepo {
         Ok(page.to_page(items, total as u64))
     }
 
-    async fn search_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>> {
+    async fn search_repos_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>> {
         let key = format!("%{key}%");
         let limit = page.limit();
         let offset = page.offset();

--- a/crates/adapters/src/persistence/sqlite/repo_repo.rs
+++ b/crates/adapters/src/persistence/sqlite/repo_repo.rs
@@ -286,7 +286,7 @@ impl RepoRepo for SqliteRepoRepo {
         Ok(rows.into_iter().map(Into::into).collect())
     }
 
-    async fn list(&self, page: Pagination) -> AppResult<Page<Repo>> {
+    async fn list_repos(&self, page: Pagination) -> AppResult<Page<Repo>> {
         let limit = page.limit();
         let offset = page.offset();
         let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM repos")
@@ -431,7 +431,7 @@ impl RepoRepo for SqliteRepoRepo {
         Ok(page.to_page(items, total as u64))
     }
 
-    async fn search_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>> {
+    async fn search_repos_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>> {
         let key = format!("%{key}%");
         let limit = page.limit();
         let offset = page.offset();

--- a/crates/app/src/repo/port.rs
+++ b/crates/app/src/repo/port.rs
@@ -44,9 +44,9 @@ pub trait RepoRepo: Send + Sync {
     async fn find_existing_ids(&self, ids: &[RepoId]) -> AppResult<Vec<RepoId>>;
     async fn find_existing_github_repo_ids(&self, ids: &[i64]) -> AppResult<Vec<i64>>;
     async fn list_by_ids(&self, ids: &[RepoId]) -> AppResult<Vec<Repo>>;
-    async fn list(&self, page: Pagination) -> AppResult<Page<Repo>>;
+    async fn list_repos(&self, page: Pagination) -> AppResult<Page<Repo>>;
     async fn list_ranked(&self, query: RepoRankQuery, page: Pagination) -> AppResult<Page<Repo>>;
-    async fn search_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>>;
+    async fn search_repos_by_key(&self, key: &str, page: Pagination) -> AppResult<Page<Repo>>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/app/src/repo/query.rs
+++ b/crates/app/src/repo/query.rs
@@ -82,7 +82,7 @@ impl RepoQueryHandler {
     }
 
     pub async fn list(&self, page: Pagination) -> AppResult<Page<Repo>> {
-        self.repos.list(page).await
+        self.repos.list_repos(page).await
     }
 
     pub async fn list_latest_pushed_candidates(
@@ -182,7 +182,7 @@ impl RepoQueryHandler {
         }
 
         let repos_page = if normalized_values.is_empty() {
-            self.repos.list(page).await?
+            self.repos.list_repos(page).await?
         } else {
             let tags = self
                 .repo_tags
@@ -437,6 +437,45 @@ impl RepoQueryHandler {
         Ok(items.pop())
     }
 
+    pub async fn search_repo_page_by_key(
+        &self,
+        key: &str,
+        page: Pagination,
+    ) -> AppResult<Page<Repo>> {
+        let key = key.trim();
+        if key.is_empty() {
+            self.repos.list_repos(page).await
+        } else {
+            self.repos.search_repos_by_key(key, page).await
+        }
+    }
+
+    pub async fn search_tag_page_by_key(
+        &self,
+        key: &str,
+        page: Pagination,
+    ) -> AppResult<Page<RepoSearchTagItem>> {
+        let key = key.trim();
+        let tags = if key.is_empty() {
+            self.repo_tags.list_tags(page).await?
+        } else {
+            self.repo_tags.search_tags_by_key(key, page).await?
+        };
+        self.enrich_search_tags(tags).await
+    }
+
+    pub async fn search_fuzzy_by_key(
+        &self,
+        key: &str,
+        repo_page: Pagination,
+        tag_page: Pagination,
+    ) -> AppResult<RepoSearchResult> {
+        Ok(RepoSearchResult {
+            repos: self.search_repo_page_by_key(key, repo_page).await?,
+            tags: self.search_tag_page_by_key(key, tag_page).await?,
+        })
+    }
+
     pub async fn search_by_key(&self, key: &str, page: Pagination) -> AppResult<RepoSearchResult> {
         let key = key.trim();
         if let Some(cache) = &self.cache {
@@ -445,21 +484,7 @@ impl RepoQueryHandler {
             }
         }
 
-        let result = if key.is_empty() {
-            RepoSearchResult {
-                repos: self.repos.list(page).await?,
-                tags: self
-                    .enrich_search_tags(self.repo_tags.list_tags(page).await?)
-                    .await?,
-            }
-        } else {
-            RepoSearchResult {
-                repos: self.repos.search_by_key(key, page).await?,
-                tags: self
-                    .enrich_search_tags(self.repo_tags.search_tags_by_key(key, page).await?)
-                    .await?,
-            }
-        };
+        let result = self.search_fuzzy_by_key(key, page, page).await?;
 
         if let Some(cache) = &self.cache {
             let _ = cache.set(key, page, &result).await;

--- a/crates/app/src/snapshot/command.rs
+++ b/crates/app/src/snapshot/command.rs
@@ -149,7 +149,7 @@ impl IngestDailySnapshots {
             .collect::<Vec<_>>();
 
         let github = self.github.clone();
-        let fetched = stream::iter(fetch_items.into_iter())
+        let fetched = stream::iter(fetch_items)
             .map(|(project, lookup_key)| {
                 let github = github.clone();
                 let fetched_at = fetched_at.clone();

--- a/crates/app/src/snapshot/query.rs
+++ b/crates/app/src/snapshot/query.rs
@@ -116,7 +116,7 @@ impl SnapshotQueryHandler {
         };
         let snapshots = self.snapshots.list_by_repo(repo_id, page).await?;
         let mut items = snapshots.items;
-        items.sort_by(|a, b| a.snapshot_date.cmp(&b.snapshot_date));
+        items.sort_by_key(|a| a.snapshot_date);
 
         if items.is_empty() {
             return Ok(SnapshotDeltasSummary {

--- a/crates/ui/src/IO/mod.rs
+++ b/crates/ui/src/IO/mod.rs
@@ -3,5 +3,6 @@ pub mod auth;
 pub mod health;
 pub mod projects;
 pub mod repos;
+pub mod search;
 pub mod seo;
 pub mod user;

--- a/crates/ui/src/IO/search.rs
+++ b/crates/ui/src/IO/search.rs
@@ -1,0 +1,32 @@
+use crate::impls::error::api_error;
+use crate::impls::state::State;
+use crate::types::search::{SearchRepoDto, SearchTagDto};
+use app::prelude::{Page, Pagination};
+use dioxus::prelude::*;
+
+#[post("/api/search/repos", state: State)]
+pub async fn search_repo_page(
+    key: String,
+    page: Pagination,
+) -> ServerFnResult<Page<SearchRepoDto>> {
+    let app_state = state.0;
+    let result = app_state
+        .repo
+        .query
+        .search_repo_page_by_key(&key, page)
+        .await
+        .map_err(api_error)?;
+    Ok(result.map(SearchRepoDto::from))
+}
+
+#[post("/api/search/tags", state: State)]
+pub async fn search_tag_page(key: String, page: Pagination) -> ServerFnResult<Page<SearchTagDto>> {
+    let app_state = state.0;
+    let result = app_state
+        .repo
+        .query
+        .search_tag_page_by_key(&key, page)
+        .await
+        .map_err(api_error)?;
+    Ok(result.map(SearchTagDto::from))
+}

--- a/crates/ui/src/components/common/pagination.rs
+++ b/crates/ui/src/components/common/pagination.rs
@@ -66,10 +66,9 @@ pub fn CommonPagination(
                         PaginationPrevious {
                             href: "#",
                             aria_disabled: if can_prev { "false" } else { "true" },
-                            style: if can_prev {
-                                "opacity: 1; pointer-events: auto;"
-                            } else {
-                                "opacity: 0.5; pointer-events: none;"
+                            style: match can_prev {
+                                true => "opacity: 1; pointer-events: auto;",
+                                false => "opacity: 0.5; pointer-events: none;",
                             },
                             onclick: move |e: MouseEvent| {
                                 e.prevent_default();

--- a/crates/ui/src/components/layout/user/color_switcher.rs
+++ b/crates/ui/src/components/layout/user/color_switcher.rs
@@ -75,10 +75,9 @@ pub fn ColorSwitcher() -> Element {
                                 });
                             },
                             span {
-                                class: if normalize_grid_theme(&preference().grid_theme) == *theme {
-                                    "block h-3 w-3 rounded-full ring-1 ring-secondary-2 ring-offset-1 ring-offset-primary"
-                                } else {
-                                    "block h-3 w-3 rounded-full"
+                                class: match normalize_grid_theme(&preference().grid_theme) == *theme {
+                                    true => "block h-3 w-3 rounded-full ring-1 ring-secondary-2 ring-offset-1 ring-offset-primary",
+                                    false => "block h-3 w-3 rounded-full",
                                 },
                                 style: "background-color: {color};",
                             }

--- a/crates/ui/src/components/layout/user/fuzzy_search/mod.rs
+++ b/crates/ui/src/components/layout/user/fuzzy_search/mod.rs
@@ -1,3 +1,6 @@
+use std::collections::HashSet;
+
+use app::prelude::{Page, Pagination};
 use dioxus::prelude::*;
 use dioxus_i18n::t;
 use dioxus_sdk_time::use_debounce;
@@ -8,15 +11,14 @@ use crate::components::tabs::{TabContent, TabList, TabTrigger, Tabs, TabsVariant
 use crate::components::ui::button::{Button, ButtonVariant};
 use crate::components::ui::dialog::{DialogContent, DialogRoot};
 use crate::components::ui::input::Input;
+use crate::components::ui::virtual_list::VirtualList;
 use crate::root::Route;
-use crate::types::search::{SearchRepoDto, SearchResultDto};
-use crate::types::tags::TagDto;
-use crate::IO::repos::search_repos;
-use app::prelude::Pagination;
+use crate::types::search::{SearchRepoDto, SearchTagDto};
+use crate::IO::search::{search_repo_page, search_tag_page};
 
-use repo_row::RepoRow;
+use repo_row::{RepoRow, RepoRowSkeleton};
 use skeleton::{FuzzySearchCachedFallback, FuzzySearchIdleFallback};
-use tag_row::TagRow;
+use tag_row::{TagRow, TagRowSkeleton};
 
 mod repo_row;
 mod skeleton;
@@ -24,16 +26,57 @@ mod tag_row;
 
 use_js!("src/js/dom_bridge.js"::mount_fuzzy_search_hotkey);
 
-fn empty_result(page: Pagination) -> SearchResultDto {
-    SearchResultDto {
-        repos: page.to_page(Vec::new(), 0),
-        tags: page.to_page(Vec::new(), 0),
+const SEARCH_PAGE_SIZE: u32 = 20;
+const SEARCH_BUFFER: usize = 8;
+const SEARCH_PREFETCH_THRESHOLD: usize = 5;
+
+fn search_pagination(offset: u32) -> Pagination {
+    Pagination {
+        limit: Some(SEARCH_PAGE_SIZE),
+        offset: Some(offset),
     }
 }
+
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct PagedSearchState<T> {
+    pub(super) items: Vec<T>,
+    pub(super) total: usize,
+    pub(super) next_offset: u32,
+    pub(super) has_more: bool,
+    pub(super) loading_initial: bool,
+    pub(super) loading_more: bool,
+    pub(super) error: Option<String>,
+    pub(super) load_more_error: Option<String>,
+}
+
+impl<T> Default for PagedSearchState<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            total: 0,
+            next_offset: 0,
+            has_more: false,
+            loading_initial: false,
+            loading_more: false,
+            error: None,
+            load_more_error: None,
+        }
+    }
+}
+
+impl<T> PagedSearchState<T> {
+    fn initial_loading() -> Self {
+        Self {
+            loading_initial: true,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub(super) struct FuzzySearchCachedResult {
-    pub(super) repos: Vec<SearchRepoDto>,
-    pub(super) tags: Vec<TagDto>,
+    pub(super) repos: PagedSearchState<SearchRepoDto>,
+    pub(super) tags: PagedSearchState<SearchTagDto>,
 }
 
 fn repo_route(repo: &SearchRepoDto) -> Route {
@@ -47,32 +90,294 @@ fn repo_route(repo: &SearchRepoDto) -> Route {
     }
 }
 
-#[derive(Clone, PartialEq)]
-enum FuzzySearchResultState {
-    Loading,
-    Ready {
-        repos: Vec<SearchRepoDto>,
-        tags: Vec<TagDto>,
-    },
-    Error(String),
+fn apply_first_page<T>(state: &mut PagedSearchState<T>, page: Page<T>) {
+    let next_offset = page.meta.offset.saturating_add(page.items.len() as u32);
+    let total = page.meta.total as usize;
+    *state = PagedSearchState {
+        items: page.items,
+        total,
+        next_offset,
+        has_more: (next_offset as u64) < page.meta.total,
+        loading_initial: false,
+        loading_more: false,
+        error: None,
+        load_more_error: None,
+    };
+}
+
+fn append_page<T, F>(state: &mut PagedSearchState<T>, page: Page<T>, key_of: F)
+where
+    T: Clone,
+    F: Fn(&T) -> String,
+{
+    let next_offset = page.meta.offset.saturating_add(page.items.len() as u32);
+    let total = page.meta.total as usize;
+    let mut items = page.items;
+
+    if items.is_empty() {
+        state.total = total;
+        state.next_offset = next_offset;
+        state.has_more = false;
+        state.loading_more = false;
+        state.load_more_error = None;
+        return;
+    }
+
+    let mut seen = state.items.iter().map(&key_of).collect::<HashSet<_>>();
+    for item in items.drain(..) {
+        if seen.insert(key_of(&item)) {
+            state.items.push(item);
+        }
+    }
+
+    state.total = total;
+    state.next_offset = next_offset;
+    state.has_more = (next_offset as u64) < page.meta.total;
+    state.loading_more = false;
+    state.load_more_error = None;
+}
+
+fn should_load_more<T>(state: &PagedSearchState<T>, idx: usize) -> bool {
+    state.has_more
+        && !state.loading_initial
+        && !state.loading_more
+        && idx.saturating_add(SEARCH_PREFETCH_THRESHOLD) >= state.items.len()
+}
+
+fn visible_item_count<T>(state: &PagedSearchState<T>) -> usize {
+    state.items.len()
 }
 
 #[derive(Props, Clone, PartialEq)]
-struct FuzzySearchResultIOProps {
-    draft: String,
-    state: FuzzySearchResultState,
-    cached: Option<FuzzySearchCachedResult>,
-    on_repo_select: Callback<Route>,
-    on_tag_select: Callback<(String, String)>,
+struct SearchLoadMoreStatusProps {
+    visible: bool,
+    loading: bool,
+    error: Option<String>,
+    on_retry: Callback<()>,
 }
 
 #[component]
-pub(super) fn FuzzySearchResultList(
-    repos: Vec<SearchRepoDto>,
-    tags: Vec<TagDto>,
+fn SearchLoadMoreStatus(props: SearchLoadMoreStatusProps) -> Element {
+    if !props.visible || (!props.loading && props.error.is_none()) {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "mt-2 flex shrink-0 items-center justify-between gap-2 rounded-md border border-primary-6 bg-primary-1 px-3 py-2 text-xs text-secondary-5",
+            if props.loading {
+                span { {t!("layout_user_fuzzy_search_loading_more")} }
+            } else if let Some(error) = props.error {
+                span { class: "truncate text-primary-error", "{error}" }
+                Button {
+                    variant: ButtonVariant::Ghost,
+                    class: "button rounded-md border border-primary-6 bg-primary px-2 py-1 text-xs hover:bg-primary-3",
+                    onclick: move |_| props.on_retry.call(()),
+                    {t!("layout_user_fuzzy_search_retry")}
+                }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct RepoResultsPanelProps {
+    state: PagedSearchState<SearchRepoDto>,
+    on_select: Callback<Route>,
+    on_prefetch: Callback<usize>,
+    on_retry: Callback<()>,
+    allow_load_more: bool,
+}
+
+#[component]
+fn RepoResultsPanel(props: RepoResultsPanelProps) -> Element {
+    if props.state.loading_initial && props.state.items.is_empty() {
+        return rsx! {
+            div { class: "flex min-h-0 flex-1 flex-col overflow-y-auto pr-1",
+                for idx in 0..6 {
+                    RepoRowSkeleton { key: "repo-loading-{idx}" }
+                }
+            }
+        };
+    }
+
+    if let Some(error) = props.state.error.clone() {
+        if props.state.items.is_empty() {
+            return rsx! {
+                div { class: "flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm text-primary-error",
+                    "{error}"
+                }
+            };
+        }
+    }
+
+    if !props.state.loading_initial && props.state.items.is_empty() && props.state.total == 0 {
+        return rsx! {
+            div { class: "flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm text-secondary-5",
+                {t!("layout_user_fuzzy_search_no_matching_repos")}
+            }
+        };
+    }
+
+    let items: Vec<SearchRepoDto> = props.state.items.clone();
+    let visible_count = visible_item_count(&props.state);
+    let allow_load_more = props.allow_load_more;
+    let on_select = props.on_select;
+    let on_prefetch = props.on_prefetch;
+    let load_more_error = props.state.load_more_error.clone();
+
+    rsx! {
+        div { class: "flex min-h-0 flex-1 flex-col",
+            div { class: "min-h-0 flex-1",
+                VirtualList {
+                    class: "h-full min-h-0 overflow-x-hidden overflow-y-auto pr-1",
+                    count: visible_count,
+                    buffer: SEARCH_BUFFER,
+                    estimate_size: |_idx| 60u32,
+                    render_item: move |idx: usize| {
+                        if let Some(repo) = items.get(idx).cloned() {
+                            let route = repo_route(&repo);
+                            let row_key = format!("repo-row-{}", repo.id);
+                            let on_select = on_select;
+                            let on_prefetch = on_prefetch;
+                            rsx! {
+                                div {
+                                    key: "{row_key}",
+                                    onvisible: move |event| {
+                                        if allow_load_more
+                                            && event.data().is_intersecting().unwrap_or(false)
+                                        {
+                                            on_prefetch.call(idx);
+                                        }
+                                    },
+                                    RepoRow {
+                                        repo,
+                                        route,
+                                        on_select,
+                                    }
+                                }
+                            }
+                        } else {
+                            rsx! {}
+                        }
+                    },
+                }
+            }
+            SearchLoadMoreStatus {
+                visible: props.allow_load_more,
+                loading: props.state.loading_more,
+                error: load_more_error,
+                on_retry: props.on_retry,
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct TagResultsPanelProps {
+    state: PagedSearchState<SearchTagDto>,
+    on_select: Callback<(String, String)>,
+    on_prefetch: Callback<usize>,
+    on_retry: Callback<()>,
+    allow_load_more: bool,
+}
+
+#[component]
+fn TagResultsPanel(props: TagResultsPanelProps) -> Element {
+    if props.state.loading_initial && props.state.items.is_empty() {
+        return rsx! {
+            div { class: "flex min-h-0 flex-1 flex-col overflow-y-auto pr-1",
+                for idx in 0..6 {
+                    TagRowSkeleton { key: "tag-loading-{idx}" }
+                }
+            }
+        };
+    }
+
+    if let Some(error) = props.state.error.clone() {
+        if props.state.items.is_empty() {
+            return rsx! {
+                div { class: "flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm text-primary-error",
+                    "{error}"
+                }
+            };
+        }
+    }
+
+    if !props.state.loading_initial && props.state.items.is_empty() && props.state.total == 0 {
+        return rsx! {
+            div { class: "flex min-h-0 flex-1 items-center justify-center p-4 text-center text-sm text-secondary-5",
+                {t!("layout_user_fuzzy_search_no_matching_tags")}
+            }
+        };
+    }
+
+    let items: Vec<SearchTagDto> = props.state.items.clone();
+    let visible_count = visible_item_count(&props.state);
+    let allow_load_more = props.allow_load_more;
+    let on_select = props.on_select;
+    let on_prefetch = props.on_prefetch;
+    let load_more_error = props.state.load_more_error.clone();
+
+    rsx! {
+        div { class: "flex min-h-0 flex-1 flex-col",
+            div { class: "min-h-0 flex-1",
+                VirtualList {
+                    class: "h-full min-h-0 overflow-x-hidden overflow-y-auto pr-1",
+                    count: visible_count,
+                    buffer: SEARCH_BUFFER,
+                    estimate_size: |_idx| 56u32,
+                    render_item: move |idx: usize| {
+                        if let Some(tag) = items.get(idx).cloned() {
+                            let key = format!("{}:{}", tag.label, tag.value);
+                            let on_select = on_select;
+                            let on_prefetch = on_prefetch;
+                            rsx! {
+                                div {
+                                    key: "{key}",
+                                    onvisible: move |event| {
+                                        if allow_load_more
+                                            && event.data().is_intersecting().unwrap_or(false)
+                                        {
+                                            on_prefetch.call(idx);
+                                        }
+                                    },
+                                    TagRow {
+                                        tag,
+                                        on_select,
+                                    }
+                                }
+                            }
+                        } else {
+                            rsx! {}
+                        }
+                    },
+                }
+            }
+            SearchLoadMoreStatus {
+                visible: props.allow_load_more,
+                loading: props.state.loading_more,
+                error: load_more_error,
+                on_retry: props.on_retry,
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+pub(super) struct FuzzySearchResultListProps {
+    repo_state: PagedSearchState<SearchRepoDto>,
+    tag_state: PagedSearchState<SearchTagDto>,
     on_repo_select: Callback<Route>,
     on_tag_select: Callback<(String, String)>,
-) -> Element {
+    on_repo_prefetch: Callback<usize>,
+    on_tag_prefetch: Callback<usize>,
+    on_repo_retry: Callback<()>,
+    on_tag_retry: Callback<()>,
+    allow_load_more: bool,
+}
+
+#[component]
+pub(super) fn FuzzySearchResultList(props: FuzzySearchResultListProps) -> Element {
     let mut active_tab = use_signal(|| Some("repos".to_string()));
     let active_tab_read: ReadSignal<Option<String>> = active_tab.into();
 
@@ -84,77 +389,79 @@ pub(super) fn FuzzySearchResultList(
             default_value: "repos".to_string(),
             on_value_change: move |value| active_tab.set(Some(value)),
             TabList {
-                TabTrigger { value: "repos".to_string(), index: 0usize, {t!("layout_user_fuzzy_search_tab_repos", count: repos.len())} }
-                TabTrigger { value: "tags".to_string(), index: 1usize, {t!("layout_user_fuzzy_search_tab_tags", count: tags.len())} }
+                TabTrigger { value: "repos".to_string(), index: 0usize, {t!("layout_user_fuzzy_search_tab_repos", count: props.repo_state.total)} }
+                TabTrigger { value: "tags".to_string(), index: 1usize, {t!("layout_user_fuzzy_search_tab_tags", count: props.tag_state.total)} }
             }
             TabContent {
                 value: "repos".to_string(),
                 index: 0usize,
                 class: "p-0 flex min-h-0 flex-1".to_string(),
-                ul { class: "min-h-0 flex-1 overflow-y-auto space-y-1",
-                    {
-                        repos
-                            .into_iter()
-                            .map(|repo| {
-                                let route = repo_route(&repo);
-                                rsx! {
-                                    RepoRow {
-                                        key: "{repo.id}",
-                                        repo,
-                                        route,
-                                        on_select: on_repo_select,
-                                    }
-                                }
-                            })
-                    }
+                RepoResultsPanel {
+                    state: props.repo_state,
+                    on_select: props.on_repo_select,
+                    on_prefetch: props.on_repo_prefetch,
+                    on_retry: props.on_repo_retry,
+                    allow_load_more: props.allow_load_more,
                 }
             }
             TabContent {
                 value: "tags".to_string(),
                 index: 1usize,
                 class: "p-0 flex min-h-0 flex-1".to_string(),
-                ul { class: "min-h-0 flex-1 overflow-y-auto space-y-1",
-                    {
-                        tags.into_iter()
-                            .map(|tag| {
-                                rsx! {
-                                    TagRow { key: "{tag.label}:{tag.value}", tag, on_select: on_tag_select }
-                                }
-                            })
-                    }
+                TagResultsPanel {
+                    state: props.tag_state,
+                    on_select: props.on_tag_select,
+                    on_prefetch: props.on_tag_prefetch,
+                    on_retry: props.on_tag_retry,
+                    allow_load_more: props.allow_load_more,
                 }
             }
         }
     }
 }
 
+#[derive(Props, Clone, PartialEq)]
+struct FuzzySearchResultIOProps {
+    draft: String,
+    repo_state: PagedSearchState<SearchRepoDto>,
+    tag_state: PagedSearchState<SearchTagDto>,
+    cached: Option<FuzzySearchCachedResult>,
+    on_repo_select: Callback<Route>,
+    on_tag_select: Callback<(String, String)>,
+    on_repo_prefetch: Callback<usize>,
+    on_tag_prefetch: Callback<usize>,
+    on_repo_retry: Callback<()>,
+    on_tag_retry: Callback<()>,
+}
+
 #[component]
 fn FuzzySearchResultIO(props: FuzzySearchResultIOProps) -> Element {
     if props.draft.trim().is_empty() {
-        return rsx! {
-            FuzzySearchIdleFallback {}
-        };
+        return rsx! { FuzzySearchIdleFallback {} };
     }
 
-    match props.state {
-        FuzzySearchResultState::Loading => rsx! {
+    if props.repo_state.loading_initial && props.tag_state.loading_initial {
+        return rsx! {
             FuzzySearchCachedFallback {
                 cached: props.cached,
                 on_repo_select: props.on_repo_select,
                 on_tag_select: props.on_tag_select,
             }
-        },
-        FuzzySearchResultState::Error(error) => rsx! {
-            div { class: "p-4 text-center text-sm text-red-500", "{error}" }
-        },
-        FuzzySearchResultState::Ready { repos, tags } => rsx! {
-            FuzzySearchResultList {
-                repos,
-                tags,
-                on_repo_select: props.on_repo_select,
-                on_tag_select: props.on_tag_select,
-            }
-        },
+        };
+    }
+
+    rsx! {
+        FuzzySearchResultList {
+            repo_state: props.repo_state,
+            tag_state: props.tag_state,
+            on_repo_select: props.on_repo_select,
+            on_tag_select: props.on_tag_select,
+            on_repo_prefetch: props.on_repo_prefetch,
+            on_tag_prefetch: props.on_tag_prefetch,
+            on_repo_retry: props.on_repo_retry,
+            on_tag_retry: props.on_tag_retry,
+            allow_load_more: true,
+        }
     }
 }
 
@@ -162,42 +469,73 @@ fn FuzzySearchResultIO(props: FuzzySearchResultIOProps) -> Element {
 pub fn FuzzySearch() -> Element {
     let mut open = use_signal(|| false);
     let mut draft = use_signal(String::new);
+    let mut session_id = use_signal(|| 0u64);
+    let mut repo_state = use_signal(PagedSearchState::<SearchRepoDto>::default);
+    let mut tag_state = use_signal(PagedSearchState::<SearchTagDto>::default);
     let mut last_success = use_signal(|| None::<FuzzySearchCachedResult>);
     let navigator = use_navigator();
     let search_trigger_id = "fuzzy-search-trigger";
 
-    let mut close_dialog = move || {
-        open.set(false);
-        draft.set(String::new());
-    };
+    let search_query = use_callback(move |query: String| {
+        let query = query.trim().to_string();
+        let next_session = session_id().wrapping_add(1);
+        session_id.set(next_session);
 
-    let mut go_repo = move |route: Route| {
-        close_dialog();
-        navigator.push(route);
-    };
-    let mut go_tag = move |pair: (String, String)| {
-        close_dialog();
-        navigator.push(Route::RepoListView {
-            tags: Some(pair.1),
-            metric: None,
-            range: None,
-            page: None,
-            size: None,
-        });
-    };
-
-    let page = Pagination {
-        limit: Some(20),
-        offset: Some(0),
-    };
-
-    let mut search = use_action({
-        move |key: String| async move {
-            if key.trim().is_empty() {
-                return Ok(empty_result(page));
-            }
-            search_repos(key, page).await
+        if query.is_empty() {
+            repo_state.set(PagedSearchState::default());
+            tag_state.set(PagedSearchState::default());
+            return;
         }
+
+        repo_state.set(PagedSearchState::initial_loading());
+        tag_state.set(PagedSearchState::initial_loading());
+
+        let repo_query = query.clone();
+        let repo_session = session_id;
+        let mut repo_state_signal = repo_state;
+        spawn(async move {
+            match search_repo_page(repo_query, search_pagination(0)).await {
+                Ok(page) => {
+                    if repo_session() != next_session {
+                        return;
+                    }
+                    repo_state_signal.with_mut(|state| apply_first_page(state, page));
+                }
+                Err(err) => {
+                    if repo_session() != next_session {
+                        return;
+                    }
+                    repo_state_signal.with_mut(|state| {
+                        *state = PagedSearchState::default();
+                        state.loading_initial = false;
+                        state.error = Some(err.to_string());
+                    });
+                }
+            }
+        });
+
+        let tag_session = session_id;
+        let mut tag_state_signal = tag_state;
+        spawn(async move {
+            match search_tag_page(query, search_pagination(0)).await {
+                Ok(page) => {
+                    if tag_session() != next_session {
+                        return;
+                    }
+                    tag_state_signal.with_mut(|state| apply_first_page(state, page));
+                }
+                Err(err) => {
+                    if tag_session() != next_session {
+                        return;
+                    }
+                    tag_state_signal.with_mut(|state| {
+                        *state = PagedSearchState::default();
+                        state.loading_initial = false;
+                        state.error = Some(err.to_string());
+                    });
+                }
+            }
+        });
     });
 
     let mut debounce_search = use_debounce(
@@ -206,9 +544,139 @@ pub fn FuzzySearch() -> Element {
             if !open() {
                 return;
             }
-            search.call(text);
+            search_query.call(text);
         },
     );
+
+    let load_more_repos = use_callback(move |idx: usize| {
+        let next_offset = {
+            let current = repo_state();
+            if !should_load_more(&current, idx) {
+                return;
+            }
+            let next_offset = current.next_offset;
+            repo_state.with_mut(|state| {
+                state.loading_more = true;
+                state.load_more_error = None;
+            });
+            next_offset
+        };
+
+        let query = draft().trim().to_string();
+        if query.is_empty() {
+            repo_state.with_mut(|state| state.loading_more = false);
+            return;
+        }
+
+        let current_session = session_id();
+        let session_signal = session_id;
+        let mut repo_state_signal = repo_state;
+        spawn(async move {
+            match search_repo_page(query, search_pagination(next_offset)).await {
+                Ok(page) => {
+                    if session_signal() != current_session {
+                        return;
+                    }
+                    repo_state_signal
+                        .with_mut(|state| append_page(state, page, |repo| repo.id.clone()));
+                }
+                Err(err) => {
+                    if session_signal() != current_session {
+                        return;
+                    }
+                    repo_state_signal.with_mut(|state| {
+                        state.loading_more = false;
+                        state.load_more_error = Some(err.to_string());
+                    });
+                }
+            }
+        });
+    });
+
+    let load_more_tags = use_callback(move |idx: usize| {
+        let next_offset = {
+            let current = tag_state();
+            if !should_load_more(&current, idx) {
+                return;
+            }
+            let next_offset = current.next_offset;
+            tag_state.with_mut(|state| {
+                state.loading_more = true;
+                state.load_more_error = None;
+            });
+            next_offset
+        };
+
+        let query = draft().trim().to_string();
+        if query.is_empty() {
+            tag_state.with_mut(|state| state.loading_more = false);
+            return;
+        }
+
+        let current_session = session_id();
+        let session_signal = session_id;
+        let mut tag_state_signal = tag_state;
+        spawn(async move {
+            match search_tag_page(query, search_pagination(next_offset)).await {
+                Ok(page) => {
+                    if session_signal() != current_session {
+                        return;
+                    }
+                    tag_state_signal.with_mut(|state| {
+                        append_page(state, page, |tag| format!("{}:{}", tag.label, tag.value));
+                    });
+                }
+                Err(err) => {
+                    if session_signal() != current_session {
+                        return;
+                    }
+                    tag_state_signal.with_mut(|state| {
+                        state.loading_more = false;
+                        state.load_more_error = Some(err.to_string());
+                    });
+                }
+            }
+        });
+    });
+
+    let retry_repos = use_callback(move |_| {
+        let current = repo_state();
+        if current.loading_more || !current.has_more {
+            return;
+        }
+        load_more_repos.call(current.items.len());
+    });
+
+    let retry_tags = use_callback(move |_| {
+        let current = tag_state();
+        if current.loading_more || !current.has_more {
+            return;
+        }
+        load_more_tags.call(current.items.len());
+    });
+
+    let close_dialog = use_callback(move |_| {
+        open.set(false);
+        draft.set(String::new());
+        repo_state.set(PagedSearchState::default());
+        tag_state.set(PagedSearchState::default());
+        session_id.with_mut(|current| *current = current.wrapping_add(1));
+    });
+
+    let go_repo = move |route: Route| {
+        close_dialog.call(());
+        navigator.push(route);
+    };
+    let go_tag = move |pair: (String, String)| {
+        close_dialog.call(());
+        navigator.push(Route::RepoListView {
+            tags: Some(pair.1),
+            metric: None,
+            range: None,
+            page: None,
+            size: None,
+        });
+    };
 
     let mut open_dialog = move || {
         if open() {
@@ -229,31 +697,22 @@ pub fn FuzzySearch() -> Element {
         });
     });
 
-    let result_state = match search.value() {
-        Some(Ok(res)) => FuzzySearchResultState::Ready {
-            repos: res().repos.items.clone(),
-            tags: res().tags.items.clone(),
-        },
-        Some(Err(err)) => FuzzySearchResultState::Error(err.to_string()),
-        None => FuzzySearchResultState::Loading,
-    };
-
-    match &result_state {
-        FuzzySearchResultState::Ready { repos, tags } => {
+    if !draft().trim().is_empty() {
+        let repo_snapshot = repo_state();
+        let tag_snapshot = tag_state();
+        if !repo_snapshot.loading_initial
+            && !tag_snapshot.loading_initial
+            && repo_snapshot.error.is_none()
+            && tag_snapshot.error.is_none()
+        {
             let cached = FuzzySearchCachedResult {
-                repos: repos.clone(),
-                tags: tags.clone(),
+                repos: repo_snapshot,
+                tags: tag_snapshot,
             };
             if (last_success)().as_ref() != Some(&cached) {
                 last_success.set(Some(cached));
             }
         }
-        FuzzySearchResultState::Error(_) => {
-            if (last_success)().is_some() {
-                last_success.set(None);
-            }
-        }
-        FuzzySearchResultState::Loading => {}
     }
 
     rsx! {
@@ -282,7 +741,7 @@ pub fn FuzzySearch() -> Element {
             on_open_change: move |v| {
                 open.set(v);
                 if !v {
-                    close_dialog();
+                    close_dialog.call(());
                 }
             },
             DialogContent { style: "top: 15%; transform: translate(-50%, 0); height: min(80vh, 34rem); max-height: min(80vh, 34rem); overflow: hidden;",
@@ -292,10 +751,10 @@ pub fn FuzzySearch() -> Element {
                     oninput: move |e: FormEvent| on_draft_change(e.value()),
                     onkeydown: move |e: KeyboardEvent| {
                         if e.key() == Key::Enter {
-                            search.call(draft());
+                            search_query.call(draft());
                         }
                         if e.key() == Key::Escape {
-                            close_dialog();
+                            close_dialog.call(());
                         }
                     },
                     placeholder: t!("layout_user_fuzzy_search_input_placeholder"),
@@ -307,13 +766,26 @@ pub fn FuzzySearch() -> Element {
                 div { class: "flex-1 min-h-0 w-full overflow-hidden",
                     FuzzySearchResultIO {
                         draft: draft(),
-                        state: result_state,
+                        repo_state: repo_state(),
+                        tag_state: tag_state(),
                         cached: (last_success)(),
                         on_repo_select: move |route| {
                             go_repo(route);
                         },
                         on_tag_select: move |pair| {
                             go_tag(pair);
+                        },
+                        on_repo_prefetch: move |idx| {
+                            load_more_repos.call(idx);
+                        },
+                        on_tag_prefetch: move |idx| {
+                            load_more_tags.call(idx);
+                        },
+                        on_repo_retry: move |_| {
+                            retry_repos.call(());
+                        },
+                        on_tag_retry: move |_| {
+                            retry_tags.call(());
                         },
                     }
                 }

--- a/crates/ui/src/components/layout/user/fuzzy_search/repo_row.rs
+++ b/crates/ui/src/components/layout/user/fuzzy_search/repo_row.rs
@@ -2,6 +2,7 @@ use dioxus::prelude::*;
 use dioxus_i18n::t;
 
 use crate::components::icons::GithubIcon;
+use crate::components::skeleton::Skeleton;
 use crate::root::Route;
 use crate::types::search::SearchRepoDto;
 
@@ -24,7 +25,7 @@ pub(super) fn RepoRow(props: RepoRowProps) -> Element {
     let route = props.route.clone();
 
     rsx! {
-        li { class: "rounded-md hover:bg-primary-3",
+        div { class: "rounded-md hover:bg-primary-3",
             button {
                 class: "w-full text-left rounded-md px-3 py-2 text-sm hover:cursor-pointer transition-colors",
                 onclick: move |_| {
@@ -36,6 +37,21 @@ pub(super) fn RepoRow(props: RepoRowProps) -> Element {
                         div { class: "font-medium text-secondary-1 truncate", "{full_name}" }
                         div { class: "text-xs text-secondary-5 truncate", "{description}" }
                     }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub(super) fn RepoRowSkeleton() -> Element {
+    rsx! {
+        div { class: "rounded-md px-3 py-2",
+            div { class: "flex items-center gap-3",
+                Skeleton { class: "skeleton h-[18px] w-[18px] shrink-0 rounded-sm" }
+                div { class: "min-w-0 flex-1 space-y-2",
+                    Skeleton { class: "skeleton h-4 w-2/5 rounded-sm" }
+                    Skeleton { class: "skeleton h-3 w-4/5 rounded-sm" }
                 }
             }
         }

--- a/crates/ui/src/components/layout/user/fuzzy_search/skeleton.rs
+++ b/crates/ui/src/components/layout/user/fuzzy_search/skeleton.rs
@@ -32,10 +32,15 @@ pub(super) fn FuzzySearchCachedFallback(props: FuzzySearchCachedFallbackProps) -
     if let Some(cached) = props.cached {
         rsx! {
             FuzzySearchResultList {
-                repos: cached.repos,
-                tags: cached.tags,
+                repo_state: cached.repos,
+                tag_state: cached.tags,
                 on_repo_select: props.on_repo_select,
                 on_tag_select: props.on_tag_select,
+                on_repo_prefetch: |_| {},
+                on_tag_prefetch: |_| {},
+                on_repo_retry: |_| {},
+                on_tag_retry: |_| {},
+                allow_load_more: false,
             }
         }
     } else {

--- a/crates/ui/src/components/layout/user/fuzzy_search/tag_row.rs
+++ b/crates/ui/src/components/layout/user/fuzzy_search/tag_row.rs
@@ -2,11 +2,12 @@ use dioxus::prelude::*;
 use dioxus_i18n::t;
 
 use crate::components::icons::TagsIcon;
-use crate::types::tags::TagDto;
+use crate::components::skeleton::Skeleton;
+use crate::types::search::SearchTagDto;
 
 #[derive(Props, Clone, PartialEq)]
 pub(super) struct TagRowProps {
-    pub tag: TagDto,
+    pub tag: SearchTagDto,
     pub on_select: Callback<(String, String)>,
 }
 
@@ -21,13 +22,13 @@ pub(super) fn TagRow(props: TagRowProps) -> Element {
         .description
         .clone()
         .unwrap_or_else(|| t!("layout_user_fuzzy_search_no_description").to_string());
-    let repos_total = props.tag.repos_total.unwrap_or(0);
+    let repos_total = props.tag.repos_total;
 
     rsx! {
-        li {
-            class: "flex items-center",
+        div {
+            class: "flex w-full min-w-0 items-center gap-2 overflow-hidden",
             button {
-                class: "w-full text-left rounded-md px-3 py-2 text-sm hover:bg-primary-3 hover:cursor-pointer transition-colors",
+                class: "min-w-0 flex-1 text-left rounded-md px-3 py-2 text-sm hover:bg-primary-3 hover:cursor-pointer transition-colors",
                 onclick: move |_| {
                     props.on_select.call((on_label.clone(), on_value.clone()));
                 },
@@ -40,7 +41,21 @@ pub(super) fn TagRow(props: TagRowProps) -> Element {
                 }
             }
 
-            div { class: "rounded-md p-1 px-2 font-mono text-secondary-5 bg-grid-accent/20", "{repos_total}" }
+            div { class: "shrink-0 rounded-md bg-grid-accent/20 p-1 px-2 font-mono text-secondary-5", "{repos_total}" }
+        }
+    }
+}
+
+#[component]
+pub(super) fn TagRowSkeleton() -> Element {
+    rsx! {
+        div { class: "flex items-center gap-2 rounded-md px-3 py-2",
+            Skeleton { class: "skeleton h-6 w-6 shrink-0 rounded-sm" }
+            div { class: "min-w-0 flex-1 space-y-2",
+                Skeleton { class: "skeleton h-4 w-1/3 rounded-sm" }
+                Skeleton { class: "skeleton h-3 w-3/5 rounded-sm" }
+            }
+            Skeleton { class: "skeleton h-7 w-10 shrink-0 rounded-sm" }
         }
     }
 }

--- a/crates/ui/src/components/ui/mod.rs
+++ b/crates/ui/src/components/ui/mod.rs
@@ -16,3 +16,4 @@ pub mod tabs;
 pub mod textarea;
 pub mod toast;
 pub mod tooltip;
+pub mod virtual_list;

--- a/crates/ui/src/components/ui/virtual_list/component.rs
+++ b/crates/ui/src/components/ui/virtual_list/component.rs
@@ -1,0 +1,16 @@
+use dioxus::prelude::*;
+pub use dioxus_primitives::virtual_list::VirtualListProps;
+
+/// Styled wrapper around the primitive `VirtualList`.
+#[component]
+pub fn VirtualList(props: VirtualListProps) -> Element {
+    rsx! {
+        dioxus_primitives::virtual_list::VirtualList {
+            count: props.count,
+            buffer: props.buffer,
+            estimate_size: props.estimate_size,
+            render_item: props.render_item,
+            attributes: props.attributes,
+        }
+    }
+}

--- a/crates/ui/src/components/ui/virtual_list/mod.rs
+++ b/crates/ui/src/components/ui/virtual_list/mod.rs
@@ -1,0 +1,2 @@
+mod component;
+pub use component::*;

--- a/crates/ui/src/components/ui/virtual_list/style.css
+++ b/crates/ui/src/components/ui/virtual_list/style.css
@@ -1,0 +1,1 @@
+/* VirtualList requires no custom styles — all layout is inline. */

--- a/crates/ui/src/components/views/admin/finder/mod.rs
+++ b/crates/ui/src/components/views/admin/finder/mod.rs
@@ -79,10 +79,9 @@ pub fn Finder() -> Element {
                 div { class: "flex flex-wrap items-center justify-between gap-2",
                     div { class: "inline-flex items-center gap-1 rounded-md border border-primary-6 bg-primary-1 p-1 text-xs",
                         button {
-                            class: if sort_by() == FinderSortBy::CreatedAtDesc {
-                                "rounded px-2 py-1 bg-secondary-2 text-primary"
-                            } else {
-                                "rounded px-2 py-1 text-secondary-5 hover:bg-primary-3"
+                            class: match sort_by() == FinderSortBy::CreatedAtDesc {
+                                true => "rounded px-2 py-1 bg-secondary-2 text-primary",
+                                false => "rounded px-2 py-1 text-secondary-5 hover:bg-primary-3",
                             },
                             onclick: move |_| {
                                 sort_by.set(FinderSortBy::CreatedAtDesc);
@@ -91,10 +90,9 @@ pub fn Finder() -> Element {
                             "Created At"
                         }
                         button {
-                            class: if sort_by() == FinderSortBy::StarsDesc {
-                                "rounded px-2 py-1 bg-secondary-2 text-primary"
-                            } else {
-                                "rounded px-2 py-1 text-secondary-5 hover:bg-primary-3"
+                            class: match sort_by() == FinderSortBy::StarsDesc {
+                                true => "rounded px-2 py-1 bg-secondary-2 text-primary",
+                                false => "rounded px-2 py-1 text-secondary-5 hover:bg-primary-3",
                             },
                             onclick: move |_| {
                                 sort_by.set(FinderSortBy::StarsDesc);

--- a/crates/ui/src/components/views/admin/projects/project_table/mod.rs
+++ b/crates/ui/src/components/views/admin/projects/project_table/mod.rs
@@ -152,13 +152,12 @@ pub(super) fn ProjectTable(props: ProjectTableProps) -> Element {
                             } else {
                                 rsx! {
                                     for item in display_items.clone() {
-                                        tr {
-                                            key: "{item.id}",
-                                            class: if props.active_id.as_deref() == Some(item.repo_id.as_str()) {
-                                                "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0"
-                                            } else {
-                                                "border-b border-primary-6 last:border-b-0"
-                                            },
+                                            tr {
+                                                key: "{item.id}",
+                                                class: match props.active_id.as_deref() == Some(item.repo_id.as_str()) {
+                                                    true => "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0",
+                                                    false => "border-b border-primary-6 last:border-b-0",
+                                                },
                                             td { class: "px-3 py-2",
                                                 span { class: if props.active_id.as_deref() == Some(item.repo_id.as_str()) { "font-medium" } else { "" }, "{item.name}" }
                                             }
@@ -216,10 +215,9 @@ pub(super) fn ProjectTable(props: ProjectTableProps) -> Element {
                                 for item in display_items.clone() {
                                     tr {
                                         key: "{item.id}",
-                                        class: if props.active_id.as_deref() == Some(item.repo_id.as_str()) {
-                                            "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0"
-                                        } else {
-                                            "border-b border-primary-6 last:border-b-0"
+                                        class: match props.active_id.as_deref() == Some(item.repo_id.as_str()) {
+                                            true => "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0",
+                                            false => "border-b border-primary-6 last:border-b-0",
                                         },
                                         td { class: "px-3 py-2",
                                             span { class: if props.active_id.as_deref() == Some(item.repo_id.as_str()) { "font-medium" } else { "" }, "{item.name}" }

--- a/crates/ui/src/components/views/admin/tags/edit_panel/group_tab/mod.rs
+++ b/crates/ui/src/components/views/admin/tags/edit_panel/group_tab/mod.rs
@@ -5,18 +5,16 @@ use dioxus::prelude::*;
 
 use crate::components::ui::button::Button;
 use crate::components::ui::input::Input;
-use crate::types::search::SearchResultDto;
-use crate::IO::repos::{bulk_update_repo_tag, search_repos};
+use crate::types::search::SearchRepoDto;
+use crate::IO::repos::bulk_update_repo_tag;
+use crate::IO::search::search_repo_page;
 
 use app::prelude::Pagination;
 
 use super::super::context::TagPanelMode;
 
-fn empty_search_result(page: Pagination) -> SearchResultDto {
-    SearchResultDto {
-        repos: page.to_page(Vec::new(), 0),
-        tags: page.to_page(Vec::new(), 0),
-    }
+fn empty_search_result(page: Pagination) -> app::prelude::Page<SearchRepoDto> {
+    page.to_page(Vec::new(), 0)
 }
 
 #[derive(Props, Clone, PartialEq)]
@@ -42,7 +40,7 @@ pub(super) fn GroupTab(props: GroupTabProps) -> Element {
             if key.trim().is_empty() {
                 return Ok(empty_search_result(page));
             }
-            search_repos(key, page).await
+            search_repo_page(key, page).await
         }
     });
 
@@ -98,8 +96,8 @@ pub(super) fn GroupTab(props: GroupTabProps) -> Element {
 
                         if let Some(Ok(result)) = repo_search.value() {
                             {
-                                let repos_for_select_all = result().repos.items.clone();
-                                let repos_for_list = result().repos.items.clone();
+                                let repos_for_select_all = result().items.clone();
+                                let repos_for_list = result().items.clone();
                                 rsx! {
                                     div { class: "space-y-2",
                                         div { class: "flex items-center gap-2",

--- a/crates/ui/src/components/views/admin/tags/tag_table/mod.rs
+++ b/crates/ui/src/components/views/admin/tags/tag_table/mod.rs
@@ -129,25 +129,22 @@ pub(super) fn TagTable(props: TagTableProps) -> Element {
                                                 rsx! {
                                                     tr {
                                                         key: "{row_id}",
-                                                        class: if is_active {
-                                                            "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0"
-                                                        } else {
-                                                            "border-b border-primary-6 last:border-b-0"
+                                                        class: match is_active {
+                                                            true => "border-b border-primary-6 bg-secondary-2 text-primary last:border-b-0",
+                                                            false => "border-b border-primary-6 last:border-b-0",
                                                         },
                                                         td {
-                                                            class: if is_active {
-                                                                "px-3 py-2 font-mono text-xs font-medium text-primary"
-                                                            } else {
-                                                                "px-3 py-2 font-mono text-xs"
+                                                            class: match is_active {
+                                                                true => "px-3 py-2 font-mono text-xs font-medium text-primary",
+                                                                false => "px-3 py-2 font-mono text-xs",
                                                             },
                                                             "{tag.label}:{tag.value}"
                                                         }
                                                         if !props.panel_open {
                                                             td {
-                                                                class: if is_active {
-                                                                    "px-3 py-2 max-w-[320px] truncate text-primary"
-                                                                } else {
-                                                                    "px-3 py-2 text-secondary-5 max-w-[320px] truncate"
+                                                                class: match is_active {
+                                                                    true => "px-3 py-2 max-w-[320px] truncate text-primary",
+                                                                    false => "px-3 py-2 text-secondary-5 max-w-[320px] truncate",
                                                                 },
                                                                 "{tag.description.clone().unwrap_or_default()}"
                                                             }

--- a/crates/ui/src/impls/i18n/locales/en-US.ftl
+++ b/crates/ui/src/impls/i18n/locales/en-US.ftl
@@ -40,6 +40,10 @@ layout_user_fuzzy_search_input_aria_label = Search
 layout_user_fuzzy_search_fallback_hi_ferris = Hi, Ferris here!
 layout_user_fuzzy_search_fallback_typing = Type a keyword and I'll find matching repos and tags
 layout_user_fuzzy_search_no_description = No description yet
+layout_user_fuzzy_search_no_matching_repos = No matching repos
+layout_user_fuzzy_search_no_matching_tags = No matching tags
+layout_user_fuzzy_search_loading_more = Loading more...
+layout_user_fuzzy_search_retry = Retry
 
 view_home_seo_title = Daily Trends
 view_home_seo_description = Discover awesome Rust open source projects with daily tracked stars, forks, issues, and ecosystem momentum.

--- a/crates/ui/src/impls/i18n/locales/zh-CN.ftl
+++ b/crates/ui/src/impls/i18n/locales/zh-CN.ftl
@@ -40,6 +40,10 @@ layout_user_fuzzy_search_input_aria_label = 搜索
 layout_user_fuzzy_search_fallback_hi_ferris = 你好，我是 Ferris！
 layout_user_fuzzy_search_fallback_typing = 输入关键词，我会帮你找到匹配的仓库和标签
 layout_user_fuzzy_search_no_description = 暂无描述
+layout_user_fuzzy_search_no_matching_repos = 没有匹配的仓库
+layout_user_fuzzy_search_no_matching_tags = 没有匹配的标签
+layout_user_fuzzy_search_loading_more = 正在加载更多...
+layout_user_fuzzy_search_retry = 重试
 
 view_home_seo_title = 每日趋势
 view_home_seo_description = 发现优质 Rust 开源项目，追踪每日 Star、Fork、Issue 与生态增长动能。

--- a/crates/ui/src/types/search.rs
+++ b/crates/ui/src/types/search.rs
@@ -1,9 +1,7 @@
 use app::prelude::Page;
-use app::repo::RepoSearchResult;
+use app::repo::{RepoSearchResult, RepoSearchTagItem};
 use domain::Repo;
 use serde::{Deserialize, Serialize};
-
-use super::tags::TagDto;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchRepoDto {
@@ -25,16 +23,35 @@ impl From<Repo> for SearchRepoDto {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchTagDto {
+    pub label: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub repos_total: u64,
+}
+
+impl From<RepoSearchTagItem> for SearchTagDto {
+    fn from(value: RepoSearchTagItem) -> Self {
+        Self {
+            label: value.label,
+            value: value.value,
+            description: value.description,
+            repos_total: value.repos_total,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchResultDto {
     pub repos: Page<SearchRepoDto>,
-    pub tags: Page<TagDto>,
+    pub tags: Page<SearchTagDto>,
 }
 
 impl From<RepoSearchResult> for SearchResultDto {
     fn from(value: RepoSearchResult) -> Self {
         Self {
             repos: value.repos.map(SearchRepoDto::from),
-            tags: value.tags.map(TagDto::from),
+            tags: value.tags.map(SearchTagDto::from),
         }
     }
 }


### PR DESCRIPTION
Fixes #9  

- API 重命名：将 `list()` 和 `search_by_key()` 重命名为更明确的 `list_repos()` 和 `search_repos_by_key()`
- 新增分页搜索 API：支持仓库和标签的独立分页查询
- UI 组件重构：模糊搜索组件支持虚拟列表、无限滚动、错误重试
- 新增 HTTP 端点：`/api/search/repos` 和 `/api/search/tags`

样式功能如下
**PC**
<img width="1882" height="951" alt="image" src="https://github.com/user-attachments/assets/ac976c21-bb71-4c91-a6dc-450cf4bcc214" />
<img width="1730" height="1003" alt="image" src="https://github.com/user-attachments/assets/a4a10e6f-2aba-4856-97d4-1b297d1d6fc2" />
<img width="1882" height="951" alt="image" src="https://github.com/user-attachments/assets/7f0f1d27-41e6-43dc-8189-4f24a734986c" />

**移动端**
<img width="604" height="1328" alt="{96783FCC-7F40-4D4F-B078-0B53914C0FA8}" src="https://github.com/user-attachments/assets/fcd9c657-aec2-4a8f-8a14-ab99b93c390d" />
