### PR TITLE
feat(repo): add support for recent ranking in repo query

### DIFF
--- a/crates/adapters/src/persistence/psql/repo_repo.rs
+++ b/crates/adapters/src/persistence/psql/repo_repo.rs
@@ -353,51 +353,84 @@ impl RepoRepo for PostgresRepoRepo {
                 .map_err(db_err)?;
 
         let rows: Vec<RepoDb> = if let Some(anchor_date) = anchor_date {
-            let window_days = match query.range {
-                RepoRankTimeRange::Daily => 1,
-                RepoRankTimeRange::Weekly => 7,
-                RepoRankTimeRange::Monthly => 30,
-            };
-            let range_start = anchor_date - Duration::days((window_days - 1) as i64);
             let order_expr = match query.metric {
                 RepoRankMetric::Star => "stars",
                 RepoRankMetric::Fork => "forks",
                 RepoRankMetric::Issue => "open_issues",
                 RepoRankMetric::Recent => "r.created_at",
             };
-            let sql = format!(
-                r#"
-                SELECT
-                  r.id, r.github_repo_id, r.full_name, r.description,
-                  r.homepage_url, r.avatar_url,
-                  COALESCE(SUM(d.stars_delta), 0)::BIGINT AS stars,
-                  COALESCE(SUM(d.forks_delta), 0)::BIGINT AS forks,
-                  ABS(COALESCE(SUM(d.open_issues_delta), 0))::BIGINT AS open_issues,
-                  r.watchers,
-                  r.created_at::TEXT AS created_at,
-                  r.last_fetched_at, r.etag
-                FROM repos r
-                LEFT JOIN snapshot_deltas d
-                  ON d.repo_id = r.id
-                 AND d.snapshot_date >= $1
-                 AND d.snapshot_date <= $2
-                GROUP BY
-                  r.id, r.github_repo_id, r.full_name, r.description,
-                  r.homepage_url, r.avatar_url,
-                  r.watchers, r.created_at,
-                  r.last_fetched_at, r.etag
-                ORDER BY {order_expr} DESC, r.stars DESC
-                LIMIT $3 OFFSET $4
-                "#
-            );
-            sqlx::query_as(&sql)
-                .bind(range_start)
-                .bind(anchor_date)
-                .bind(limit as i64)
-                .bind(offset as i64)
-                .fetch_all(&self.pool)
-                .await
-                .map_err(db_err)?
+            if query.range == RepoRankTimeRange::All {
+                let sql = format!(
+                    r#"
+                    SELECT
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      COALESCE(SUM(d.stars_delta), 0)::BIGINT AS stars,
+                      COALESCE(SUM(d.forks_delta), 0)::BIGINT AS forks,
+                      ABS(COALESCE(SUM(d.open_issues_delta), 0))::BIGINT AS open_issues,
+                      r.watchers,
+                      r.created_at::TEXT AS created_at,
+                      r.last_fetched_at, r.etag
+                    FROM repos r
+                    LEFT JOIN snapshot_deltas d
+                      ON d.repo_id = r.id
+                    GROUP BY
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      r.watchers, r.created_at,
+                      r.last_fetched_at, r.etag
+                    ORDER BY {order_expr} DESC, r.stars DESC
+                    LIMIT $1 OFFSET $2
+                    "#
+                );
+                sqlx::query_as(&sql)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(db_err)?
+            } else {
+                let window_days = match query.range {
+                    RepoRankTimeRange::Daily => 1,
+                    RepoRankTimeRange::Weekly => 7,
+                    RepoRankTimeRange::Monthly => 30,
+                    RepoRankTimeRange::All => unreachable!(),
+                };
+                let range_start = anchor_date - Duration::days((window_days - 1) as i64);
+                let sql = format!(
+                    r#"
+                    SELECT
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      COALESCE(SUM(d.stars_delta), 0)::BIGINT AS stars,
+                      COALESCE(SUM(d.forks_delta), 0)::BIGINT AS forks,
+                      ABS(COALESCE(SUM(d.open_issues_delta), 0))::BIGINT AS open_issues,
+                      r.watchers,
+                      r.created_at::TEXT AS created_at,
+                      r.last_fetched_at, r.etag
+                    FROM repos r
+                    LEFT JOIN snapshot_deltas d
+                      ON d.repo_id = r.id
+                     AND d.snapshot_date >= $1
+                     AND d.snapshot_date <= $2
+                    GROUP BY
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      r.watchers, r.created_at,
+                      r.last_fetched_at, r.etag
+                    ORDER BY {order_expr} DESC, r.stars DESC
+                    LIMIT $3 OFFSET $4
+                    "#
+                );
+                sqlx::query_as(&sql)
+                    .bind(range_start)
+                    .bind(anchor_date)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(db_err)?
+            }
         } else {
             let fallback_order = match query.metric {
                 RepoRankMetric::Star => "stars",

--- a/crates/adapters/src/persistence/sqlite/repo_repo.rs
+++ b/crates/adapters/src/persistence/sqlite/repo_repo.rs
@@ -354,51 +354,84 @@ impl RepoRepo for SqliteRepoRepo {
                 .map_err(db_err)?;
 
         let rows: Vec<RepoDb> = if let Some(anchor_date) = anchor_date {
-            let window_days = match query.range {
-                RepoRankTimeRange::Daily => 1,
-                RepoRankTimeRange::Weekly => 7,
-                RepoRankTimeRange::Monthly => 30,
-            };
-            let range_start = anchor_date - Duration::days((window_days - 1) as i64);
             let order_expr = match query.metric {
                 RepoRankMetric::Star => "stars",
                 RepoRankMetric::Fork => "forks",
                 RepoRankMetric::Issue => "open_issues",
                 RepoRankMetric::Recent => "r.created_at",
             };
-            let sql = format!(
-                r#"
-                SELECT
-                  r.id, r.github_repo_id, r.full_name, r.description,
-                  r.homepage_url, r.avatar_url,
-                  COALESCE(SUM(d.stars_delta), 0) AS stars,
-                  COALESCE(SUM(d.forks_delta), 0) AS forks,
-                  ABS(COALESCE(SUM(d.open_issues_delta), 0)) AS open_issues,
-                  r.watchers,
-                  r.created_at,
-                  r.last_fetched_at, r.etag
-                FROM repos r
-                LEFT JOIN snapshot_deltas d
-                  ON d.repo_id = r.id
-                 AND d.snapshot_date >= ?
-                 AND d.snapshot_date <= ?
-                GROUP BY
-                  r.id, r.github_repo_id, r.full_name, r.description,
-                  r.homepage_url, r.avatar_url,
-                  r.watchers, r.created_at,
-                  r.last_fetched_at, r.etag
-                ORDER BY {order_expr} DESC, r.stars DESC
-                LIMIT ? OFFSET ?
-                "#
-            );
-            sqlx::query_as(&sql)
-                .bind(range_start)
-                .bind(anchor_date)
-                .bind(limit as i64)
-                .bind(offset as i64)
-                .fetch_all(&self.pool)
-                .await
-                .map_err(db_err)?
+            if query.range == RepoRankTimeRange::All {
+                let sql = format!(
+                    r#"
+                    SELECT
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      COALESCE(SUM(d.stars_delta), 0) AS stars,
+                      COALESCE(SUM(d.forks_delta), 0) AS forks,
+                      ABS(COALESCE(SUM(d.open_issues_delta), 0)) AS open_issues,
+                      r.watchers,
+                      r.created_at,
+                      r.last_fetched_at, r.etag
+                    FROM repos r
+                    LEFT JOIN snapshot_deltas d
+                      ON d.repo_id = r.id
+                    GROUP BY
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      r.watchers, r.created_at,
+                      r.last_fetched_at, r.etag
+                    ORDER BY {order_expr} DESC, r.stars DESC
+                    LIMIT ? OFFSET ?
+                    "#
+                );
+                sqlx::query_as(&sql)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(db_err)?
+            } else {
+                let window_days = match query.range {
+                    RepoRankTimeRange::Daily => 1,
+                    RepoRankTimeRange::Weekly => 7,
+                    RepoRankTimeRange::Monthly => 30,
+                    RepoRankTimeRange::All => unreachable!(),
+                };
+                let range_start = anchor_date - Duration::days((window_days - 1) as i64);
+                let sql = format!(
+                    r#"
+                    SELECT
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      COALESCE(SUM(d.stars_delta), 0) AS stars,
+                      COALESCE(SUM(d.forks_delta), 0) AS forks,
+                      ABS(COALESCE(SUM(d.open_issues_delta), 0)) AS open_issues,
+                      r.watchers,
+                      r.created_at,
+                      r.last_fetched_at, r.etag
+                    FROM repos r
+                    LEFT JOIN snapshot_deltas d
+                      ON d.repo_id = r.id
+                     AND d.snapshot_date >= ?
+                     AND d.snapshot_date <= ?
+                    GROUP BY
+                      r.id, r.github_repo_id, r.full_name, r.description,
+                      r.homepage_url, r.avatar_url,
+                      r.watchers, r.created_at,
+                      r.last_fetched_at, r.etag
+                    ORDER BY {order_expr} DESC, r.stars DESC
+                    LIMIT ? OFFSET ?
+                    "#
+                );
+                sqlx::query_as(&sql)
+                    .bind(range_start)
+                    .bind(anchor_date)
+                    .bind(limit as i64)
+                    .bind(offset as i64)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(db_err)?
+            }
         } else {
             let fallback_order = match query.metric {
                 RepoRankMetric::Star => "stars",

--- a/crates/app/src/repo/port.rs
+++ b/crates/app/src/repo/port.rs
@@ -15,8 +15,10 @@ pub enum RepoRankMetric {
     Recent,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum RepoRankTimeRange {
+    #[default]
+    All,
     Daily,
     Weekly,
     Monthly,

--- a/crates/ui/src/IO/repos.rs
+++ b/crates/ui/src/IO/repos.rs
@@ -52,7 +52,7 @@ pub async fn list_repos_with_query(query: RepoListQuery) -> ServerFnResult<Page<
             .list_ranked_with_tags(
                 RepoRankQuery {
                     metric: RepoRankMetric::Recent,
-                    range: RepoRankTimeRange::Monthly,
+                    range: RepoRankTimeRange::All,
                 },
                 query.page,
             )

--- a/crates/ui/src/IO/repos.rs
+++ b/crates/ui/src/IO/repos.rs
@@ -13,7 +13,8 @@ use dioxus::prelude::*;
 use app::prelude::{DurationRange, LatestPushedRepoQuery, Page, Pagination};
 use app::repo::{
     BulkTagUpdateAction, BulkUpdateRepoTagCommand, ImportTagCommand, ImportTagsCommand,
-    ReplaceRepoTagsCommand, RepoListQuery, RepoRankMetric, RepoRankQuery, TagInput,
+    ReplaceRepoTagsCommand, RepoListQuery, RepoRankMetric, RepoRankQuery, RepoRankTimeRange,
+    TagInput,
 };
 use serde::Deserialize;
 
@@ -44,6 +45,19 @@ pub async fn list_repos_with_query(query: RepoListQuery) -> ServerFnResult<Page<
             .map_err(api_error)?
     } else if query.metric.is_none() && query.range.is_none() {
         return list_repos(query.page).await;
+    } else if query.metric == Some(RepoRankMetric::Recent) {
+        app_state
+            .repo
+            .query
+            .list_ranked_with_tags(
+                RepoRankQuery {
+                    metric: RepoRankMetric::Recent,
+                    range: RepoRankTimeRange::Monthly,
+                },
+                query.page,
+            )
+            .await
+            .map_err(api_error)?
     } else if let (Some(metric), Some(range)) = (query.metric, query.range) {
         app_state
             .repo

--- a/crates/ui/src/components/views/home/rank_panel/mod.rs
+++ b/crates/ui/src/components/views/home/rank_panel/mod.rs
@@ -41,6 +41,7 @@ pub(super) fn stat_icon_mobile_tab(tab: RankType) -> Element {
 
 fn rank_range_query(range: TimeRange) -> &'static str {
     match range {
+        TimeRange::All => "all",
         TimeRange::Daily => "daily",
         TimeRange::Weekly => "weekly",
         TimeRange::Monthly => "monthly",
@@ -149,7 +150,14 @@ pub(super) fn HomeRankPanel() -> Element {
                             to: Route::RepoListView {
                                 tags: None,
                                 metric: Some(rank_metric_query(active_tab()).to_string()),
-                                range: Some(rank_range_query(time_range()).to_string()),
+                                range: Some(
+                                    rank_range_query(if active_tab() == RankType::Recent {
+                                        TimeRange::All
+                                    } else {
+                                        time_range()
+                                    })
+                                    .to_string(),
+                                ),
                                 page: None,
                                 size: None,
                             },
@@ -255,6 +263,7 @@ pub(super) fn rank_desc(tab: RankType) -> String {
 
 pub(super) fn time_range_text(range: TimeRange) -> String {
     match range {
+        TimeRange::All => "All".to_string(),
         TimeRange::Daily => t!("view_home_rank_panel_range_daily").to_string(),
         TimeRange::Weekly => t!("view_home_rank_panel_range_weekly").to_string(),
         TimeRange::Monthly => t!("view_home_rank_panel_range_monthly").to_string(),

--- a/crates/ui/src/components/views/home/rank_panel/rank_panel_list/mod.rs
+++ b/crates/ui/src/components/views/home/rank_panel/rank_panel_list/mod.rs
@@ -24,7 +24,11 @@ pub(super) fn HomeRankPanelList(props: HomeRankPanelListProps) -> Element {
                 offset: Some(0),
             },
             metric: Some((props.active_tab)()),
-            range: Some((props.time_range)()),
+            range: Some(if (props.active_tab)() == RankType::Recent {
+                TimeRange::All
+            } else {
+                (props.time_range)()
+            }),
             tags: None,
         })
     })?;

--- a/crates/ui/src/components/views/repo/list/mod.rs
+++ b/crates/ui/src/components/views/repo/list/mod.rs
@@ -165,6 +165,7 @@ pub(super) fn parse_filter_type(range: Option<&str>, metric: Option<&str>) -> Fi
         return FilterType::Total;
     }
     match range.unwrap_or_default().trim().to_lowercase().as_str() {
+        "all" | "total" => FilterType::Total,
         "daily" | "day" => FilterType::Daily,
         "monthly" | "month" => FilterType::Monthly,
         "weekly" | "week" => FilterType::Weekly,
@@ -192,10 +193,10 @@ pub(super) fn sort_metric(sort: SortType) -> RepoRankMetric {
 
 pub(super) fn filter_range(filter: FilterType) -> RepoRankTimeRange {
     match filter {
+        FilterType::Total => RepoRankTimeRange::All,
         FilterType::Daily => RepoRankTimeRange::Daily,
         FilterType::Weekly => RepoRankTimeRange::Weekly,
         FilterType::Monthly => RepoRankTimeRange::Monthly,
-        FilterType::Total => RepoRankTimeRange::Weekly,
     }
 }
 
@@ -210,10 +211,10 @@ pub(super) fn sort_metric_query(sort: SortType) -> &'static str {
 
 pub(super) fn filter_range_query(filter: FilterType) -> &'static str {
     match filter {
+        FilterType::Total => "all",
         FilterType::Daily => "daily",
         FilterType::Weekly => "weekly",
         FilterType::Monthly => "monthly",
-        FilterType::Total => "weekly",
     }
 }
 

--- a/crates/ui/src/components/views/repo/list/repo_list/mod.rs
+++ b/crates/ui/src/components/views/repo/list/repo_list/mod.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use app::prelude::Pagination as PageQuery;
-use app::repo::RepoListQuery;
+use app::repo::{RepoListQuery, RepoRankTimeRange};
 
 use crate::IO::repos::list_repos_with_query;
 
@@ -10,7 +10,7 @@ pub(super) mod skeleton;
 
 use super::{
     filter_range, sort_metric, FilterType, ListSummary, RepoListCachedPage, RepoListContext,
-    RepoListHeroType,
+    RepoListHeroType, SortType,
 };
 use repo_list_content::RepoListContent;
 
@@ -30,11 +30,13 @@ pub(super) fn RepoListIO() -> Element {
         let query = RepoListQuery {
             page: page_query,
             metric: Some(sort_metric(sort_type)),
-            range: if filter_type == FilterType::Total {
-                None
-            } else {
-                Some(filter_range(filter_type))
-            },
+            range: Some(
+                if sort_type == SortType::AddTime || filter_type == FilterType::Total {
+                    RepoRankTimeRange::All
+                } else {
+                    filter_range(filter_type)
+                },
+            ),
             tags: (!active_tags.is_empty()).then_some(active_tags),
         };
         async move { list_repos_with_query(query).await }


### PR DESCRIPTION
Fixes #13 

Make the `list_repos_with_query` interface compatible to ensure that the `list_ranked_with_tags` method can be used when passing the Recent parameter.

The results are as follows

<img width="1225" height="1199" alt="image" src="https://github.com/user-attachments/assets/698ab320-6190-4aad-848f-d53bf6f28f43" />

<img width="1220" height="1220" alt="image" src="https://github.com/user-attachments/assets/8cb3f233-8c5c-43bf-9ba5-dc927653e30d" />


